### PR TITLE
chore: release v1.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "TabLinkList",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "List open tabs, select them, and copy titles and URLs.",
     "permissions": [
         "tabs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-link-list",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-link-list",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tab-link-list",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to `1.0.2` in `package.json` and `manifest.json`

## What's new in v1.0.2

- Filter tabs by title or URL (case-insensitive partial match)
- Tabs hidden by the filter are automatically deselected
- Unified bottom bar merging format selector and copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)