### PR TITLE
chore: improve Claude Code setup and fix README version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,11 @@ This is a Chrome Extension Manifest V3 popup built with React 19 + TypeScript + 
 **Styling:** CSS Modules (`.module.css`) per component; global styles in `src/popup/App.css` and `src/popup/index.css`.
 
 Tests are in `src/**/*.test.ts` and run in a Node environment (no DOM).
+
+## Common Gotchas
+
+- **Chrome API unavailable in dev:** `chrome.tabs` doesn't exist in the browser dev server — `useTabs` automatically falls back to mock data. Test real tab behavior by building and loading the extension.
+- **Must reload extension after build:** After `npm run build`, go to `chrome://extensions` and click the reload icon for TabLinkList — Chrome does not hot-reload unpacked extensions.
+- **`main` branch is push-protected:** Never push directly to `main`. Always use a feature or release branch and open a PR.
+- **Version must be bumped in two places:** `package.json` and `manifest.json` must be updated together on release — they are not linked automatically.
+- **Releasing to Chrome Web Store:** Manual upload via the dashboard is preferred; automated credentials (`CHROME_CLIENT_ID` etc.) are not configured. See `.claude/skills/publish-extension.md` for the full release flow.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm run lint
 
 | Layer | Technology |
 |-------|-----------|
-| UI | [React 18](https://react.dev/) |
+| UI | [React 19](https://react.dev/) |
 | Language | [TypeScript](https://www.typescriptlang.org/) |
 | Build | [Vite](https://vite.dev/) + [@crxjs/vite-plugin](https://crxjs.dev/vite-plugin/) |
 | Styling | Vanilla CSS Modules |


### PR DESCRIPTION
## Summary

- Add **Common Gotchas** section to `CLAUDE.md` covering: Chrome API mock fallback in dev, manual extension reload after build, `main` branch push protection, dual version bump requirement, and Chrome Web Store manual release flow
- Fix **README.md** tech stack table listing React 18 → React 19 (actual version in use)
- Expand `.claude/settings.local.json` with additional allowed commands (`npm run:*`, `git status/diff/log/commit/push`, `npx vitest:*`) and a PostToolUse lint hook (local file, not committed)

## Test plan

- [x] Verify `CLAUDE.md` renders correctly on GitHub
- [x] Verify README tech stack shows React 19

🤖 Generated with [Claude Code](https://claude.com/claude-code)