### PR TITLE
chore: release v1.0.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "TabLinkList",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "List open tabs, select them, and copy titles and URLs.",
     "permissions": [
         "tabs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tab-link-list",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version to 1.0.3 in `package.json` and `manifest.json`

## Changes since v1.0.2
- feat: keyboard operation support (Tab navigation, Space to toggle, Ctrl+Enter to copy)
- fix: single Tab stop per tab item (role=checkbox on row div)
- fix: tsc type error in vite.config.ts (use vitest/config defineConfig)

## Release checklist
- [x] Version bumped in `package.json` and `manifest.json`
- [x] Production build passes
- [x] `tab-link-list-v1.0.3.zip` ready for Chrome Web Store upload