### PR TITLE
docs: update README and requirements for v1.0.3 keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   | **Markdown** | `[Title](URL)` |
   | **HTML** | `<a href="URL">Title</a>` |
 - 📋 **One-click copy** — Copies selected tabs to the clipboard with a "Copied!" confirmation.
+- ⌨️ **Full keyboard support** — All operations are completable without a mouse.
 
 ---
 
@@ -59,6 +60,20 @@ Install directly from the [Chrome Web Store](https://chromewebstore.google.com/d
 4. Pick a copy format (**Text**, **Markdown**, or **HTML**) in the bottom bar.
 5. Click **Copy** — the selected tabs' titles and URLs are copied to your clipboard.
 
+### Keyboard Operation
+
+The popup can be operated entirely with the keyboard:
+
+| Action | Key |
+|--------|-----|
+| Open popup | Chrome keyboard shortcut (configurable in `chrome://extensions/shortcuts`) |
+| Toggle tab selection | `Space` (when a tab item is focused) |
+| Navigate between elements | `Tab` / `Shift+Tab` |
+| Trigger copy (global) | `Ctrl+Enter` |
+| Trigger copy (via button) | Focus Copy button with `Tab`, then `Enter` |
+
+**Tab sequence:** Select All checkbox → filter input → tab items → format buttons → Copy button
+
 ---
 
 ## Development
@@ -72,6 +87,9 @@ npm run build
 
 # Lint
 npm run lint
+
+# Run tests
+npm test
 ```
 
 ---
@@ -84,6 +102,7 @@ npm run lint
 | Language | [TypeScript](https://www.typescriptlang.org/) |
 | Build | [Vite](https://vite.dev/) + [@crxjs/vite-plugin](https://crxjs.dev/vite-plugin/) |
 | Styling | Vanilla CSS Modules |
+| Testing | [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) |
 | Platform | Chrome Extension Manifest V3 |
 
 ---

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -25,6 +25,7 @@ TabLinkList is a Chrome extension that lists all open tabs in the current window
     - A text input in the header allows filtering tabs by partial match on title or URL (case-insensitive).
     - Only matching tabs are shown in the list.
     - Tabs hidden by the filter are automatically deselected.
+    - The filter input is auto-focused when the popup opens.
 
 - **Selection Controls**:
     - "Select All" checkbox in the header toggles selection for all currently visible (filtered) tabs.
@@ -40,13 +41,29 @@ TabLinkList is a Chrome extension that lists all open tabs in the current window
     - Copies selected tabs to the clipboard in the chosen format.
     - Visual feedback on success (button changes to "Copied!").
 
+### 2. Keyboard Operation
+
+- All operations can be completed using only the keyboard after opening the popup.
+- **Focus management**: Filter input receives focus automatically when the popup opens.
+- **Tab sequence**: Select All checkbox → filter input → tab items → format buttons → Copy button
+- **Key bindings**:
+
+    | Action | Key |
+    |--------|-----|
+    | Toggle tab selection | `Space` (when tab item is focused) |
+    | Navigate between elements | `Tab` / `Shift+Tab` |
+    | Toggle Select All | `Tab` to focus, then `Space` |
+    | Trigger copy (global) | `Ctrl+Enter` |
+    | Trigger copy (via button) | `Tab` to focus Copy button, then `Enter` |
+
 ## Technical Requirements
 
 ### 1. Technology Stack
-- **Framework**: React 18+
+- **Framework**: React 19+
 - **Language**: TypeScript
 - **Build Tool**: Vite (with `@crxjs/vite-plugin`)
 - **Styling**: Vanilla CSS Modules (`*.module.css`)
+- **Testing**: Vitest + Testing Library
 
 ### 2. Chrome Extension Architecture
 - **Manifest Version**: V3
@@ -63,3 +80,4 @@ TabLinkList is a Chrome extension that lists all open tabs in the current window
 - Custom scrollbar
 - Entry animations for list items
 - Clear distinction between selected and unselected states
+- `:focus-visible` outlines on all interactive elements for keyboard navigation

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -61,7 +61,7 @@ function App() {
     setTimeout(() => setCopyStatus(false), 2000);
   };
 
-  // Ctrl+Enter (Windows/Linux) / Cmd+Enter (macOS) from anywhere triggers copy
+  // Ctrl+Enter from anywhere triggers copy
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.key === 'Enter') {


### PR DESCRIPTION
## Summary
- README: add keyboard operation feature, keyboard shortcut table, Tab sequence, `npm test` command, Testing Library to Tech Stack
- docs/requirements.md: add keyboard operation section (focus management, Tab sequence, key bindings), update React version to 19+, add Vitest to tech stack, add focus-visible to UI/UX goals
- src/popup/App.tsx: fix stale comment that still mentioned Cmd+Enter (macOS)