### PR TITLE
ci: add explicit CodeQL workflow to replace Default Setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
Adds `.github/workflows/codeql.yml` to replace GitHub's Default CodeQL Setup.

## Problem
The Default Setup was running `Analyze (actions)` and `Analyze (javascript-typescript)` correctly, but the PR check page showed a "CodeQL" status check reporting "2 configurations not found" — because there was no explicit workflow file to satisfy it.

## Solution
Explicit workflow that analyzes `actions` and `javascript-typescript` via matrix, plus a weekly scheduled scan (Monday 03:00 UTC).

After merging, the GitHub Default Setup should be disabled in **Settings → Code security → Code scanning → Default Setup**.