### PR TITLE
ci: harden supply chain security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review by the repo owner.
+* @shionit

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    // Automatically pin GitHub Actions to commit SHAs and keep them updated.
+    "helpers:pinGitHubActionDigests"
+  ],
+  // Post a Dependency Dashboard issue so updates are visible without PR spam.
+  "dependencyDashboard": true,
+  // Batch updates on Saturdays before 6 AM to keep the week's PRs predictable.
+  "schedule": ["before 9am on saturday"],
+  // Cap concurrent open Renovate PRs to avoid flooding the queue.
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    // Auto-merge non-major devDependency updates — low blast radius for a
+    // private extension repo with no published API surface.
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    // Group ESLint-family packages into one PR to reduce noise.
+    {
+      "groupName": "eslint packages",
+      "matchPackageNames": ["eslint", "typescript-eslint"],
+      "matchPackagePatterns": ["^eslint-plugin-", "^@eslint/"]
+    },
+    // Group all @testing-library/* together — they tend to release in sync.
+    {
+      "groupName": "testing-library packages",
+      "matchPackagePatterns": ["^@testing-library/"]
+    },
+    // Group Vite + its plugins together — they share the Rollup peer dependency.
+    {
+      "groupName": "vite packages",
+      "matchPackageNames": ["vite"],
+      "matchPackagePatterns": ["^@vitejs/", "^@crxjs/"]
+    },
+    // Group TypeScript + all @types/* together.
+    {
+      "groupName": "TypeScript type packages",
+      "matchPackageNames": ["typescript"],
+      "matchPackagePatterns": ["^@types/"]
+    },
+    // Major runtime dependency bumps (react, react-dom) require manual review.
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
 
+# Minimal permissions: read-only by default; no write access needed for CI.
 permissions:
   contents: read
 
@@ -17,11 +18,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Restrict outbound network to only the hosts this job legitimately needs.
+      # Use egress-policy: audit during initial rollout to observe without blocking.
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+# Runs on every PR to catch newly introduced vulnerable or license-incompatible
+# dependencies before they land on main.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # Blocks PRs that introduce packages with known vulnerabilities (severity >= high)
+      # or packages with disallowed licenses (AGPL prevents distribution in the CWS).
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-3.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest published version of TabLinkList is actively maintained.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub Private Security Advisories](https://github.com/shionit/tab-link-list/security/advisories/new)
+to report a vulnerability privately. You can expect an initial response within 7 days.
+
+## Scope
+
+This extension requests only the `tabs` permission and never communicates with
+external servers — all processing happens locally in the browser popup.
+
+Vulnerabilities of interest include:
+
+- Malicious code injected via a compromised dependency (supply chain attack)
+- Content-Security-Policy bypasses in the extension popup
+- Unintended clipboard data exfiltration


### PR DESCRIPTION
## Summary

- **SHA-pin all GitHub Actions** — `checkout` and `setup-node` now reference full commit SHAs instead of mutable tags, eliminating tag-hijack supply chain risk
- **StepSecurity Harden Runner** added to both workflows with `egress-policy: audit` (monitor-first; switch to `block` after reviewing the allowed-hosts report)
- **Dependency Review workflow** — blocks PRs that introduce high/critical CVEs or AGPL-licensed packages
- **Renovate config** — weekly batched updates with SHA digest pinning for Actions, grouped rules for ESLint/testing/Vite/TypeScript packages, and automerge for non-major devDependency patches/minors
- **CODEOWNERS** — requires `@shionit` review on all files
- **SECURITY.md** — directs reporters to GitHub Private Security Advisories

## Test plan

- [x] CI workflow passes on this PR
- [x] Dependency Review workflow runs and passes (no new deps introduced)
- [ ] After merge: verify Renovate opens a Dependency Dashboard issue
- [ ] After a few CI runs: review Harden Runner egress report and consider switching to `egress-policy: block`

🤖 Generated with [Claude Code](https://claude.com/claude-code)