### PR TITLE
docs: fix stale schedule comment in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
   ],
   // Post a Dependency Dashboard issue so updates are visible without PR spam.
   "dependencyDashboard": true,
-  // Batch updates on Saturdays before 6 AM to keep the week's PRs predictable.
+  // Batch updates on Saturdays before 9 AM to keep the week's PRs predictable.
   "schedule": ["before 9am on saturday"],
   // Cap concurrent open Renovate PRs to avoid flooding the queue.
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## Summary

- Fixes the inline comment that still said "6 AM" after the schedule was changed to `before 9am on saturday`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)